### PR TITLE
商品削除機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def new
     @item = Item.new
@@ -33,6 +33,15 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item)
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @item.user_id == current_user.id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <%# 商品購入機能を実装後、売切判定を記載する%>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% elsif user_signed_in? && current_user.id != @item.user_id %>
         <%= link_to '購入画面に進む', "#", class: "item-red-btn" %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
   resources :items do
-    resources :orders, only: [:index, :create, :show, :edit, :update]
+    resources :orders, only: [:index, :create, :show, :edit, :update, :destroy]
   end
   resources :users
   


### PR DESCRIPTION
# What
商品削除機能の実装
　・ ログイン状態の場合にのみ、自身が出品した商品情報を削除できること。
　・ 削除が完了したら、トップページに遷移すること。

# Why
・出品した商品を削除できるようにするため。

# Gyazo_URL
 ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/e641f782ec04ac5129dfb579708d7836